### PR TITLE
Config option to disable signing keys cache-control

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ export PATH := $(PWD)/bin:$(PATH)
 
 VERSION ?= $(shell ./scripts/git-version)
 
-DOCKER_REPO=quay.io/dexidp/dex
+DOCKER_REPO=ghcr.io/aserto-dev/dex-test
 DOCKER_IMAGE=$(DOCKER_REPO):$(VERSION)
 
 $( shell mkdir -p bin )
@@ -99,7 +99,7 @@ fix: bin/golangci-lint ## Fix lint violations
 
 .PHONY: docker-image
 docker-image:
-	@sudo docker build -t $(DOCKER_IMAGE) .
+	@docker build -t $(DOCKER_IMAGE) .
 
 .PHONY: proto-old
 proto-old: bin/protoc-old bin/protoc-gen-go-old

--- a/cmd/dex/config.go
+++ b/cmd/dex/config.go
@@ -320,6 +320,9 @@ type Expiry struct {
 	// SigningKeys defines the duration of time after which the SigningKeys will be rotated.
 	SigningKeys string `json:"signingKeys"`
 
+	// SigningKeysNoStore disables browser caching of signing key reponses.
+	SigningKeysNoStore bool `json:"signingKeysNoStore"`
+
 	// IdTokens defines the duration of time for which the IdTokens will be valid.
 	IDTokens string `json:"idTokens"`
 

--- a/cmd/dex/config_test.go
+++ b/cmd/dex/config_test.go
@@ -116,6 +116,7 @@ staticPasswords:
 
 expiry:
   signingKeys: "7h"
+  signingKeysNoStore: true
   idTokens: "25h"
   authRequests: "25h"
   deviceRequests: "10m"
@@ -197,10 +198,11 @@ logger:
 			},
 		},
 		Expiry: Expiry{
-			SigningKeys:    "7h",
-			IDTokens:       "25h",
-			AuthRequests:   "25h",
-			DeviceRequests: "10m",
+			SigningKeys:        "7h",
+			SigningKeysNoStore: true,
+			IDTokens:           "25h",
+			AuthRequests:       "25h",
+			DeviceRequests:     "10m",
 		},
 		Logger: Logger{
 			Level:  "debug",

--- a/cmd/dex/serve.go
+++ b/cmd/dex/serve.go
@@ -271,6 +271,7 @@ func runServe(options serveOptions) error {
 		Now:                    now,
 		PrometheusRegistry:     prometheusRegistry,
 		HealthChecker:          healthChecker,
+		SigningKeyNoStore:      c.Expiry.SigningKeysNoStore,
 	}
 	if c.Expiry.SigningKeys != "" {
 		signingKeys, err := time.ParseDuration(c.Expiry.SigningKeys)

--- a/server/handlers.go
+++ b/server/handlers.go
@@ -62,7 +62,12 @@ func (s *Server) handlePublicKeys(w http.ResponseWriter, r *http.Request) {
 		maxAge = time.Minute * 2
 	}
 
-	w.Header().Set("Cache-Control", fmt.Sprintf("max-age=%d, must-revalidate", int(maxAge.Seconds())))
+	cacheControl := fmt.Sprintf("max-age=%d, must-revalidate", int(maxAge.Seconds()))
+	if s.signingKeyNoStore {
+		cacheControl = "no-store"
+	}
+
+	w.Header().Set("Cache-Control", cacheControl)
 	w.Header().Set("Content-Type", "application/json")
 	w.Header().Set("Content-Length", strconv.Itoa(len(data)))
 	w.Write(data)

--- a/server/server.go
+++ b/server/server.go
@@ -88,6 +88,9 @@ type Config struct {
 	AuthRequestsValidFor   time.Duration // Defaults to 24 hours
 	DeviceRequestsValidFor time.Duration // Defaults to 5 minutes
 
+	// If true, disable browser caching of signing keys.
+	SigningKeyNoStore bool
+
 	// Refresh token expiration settings
 	RefreshTokenPolicy *RefreshTokenPolicy
 
@@ -179,6 +182,8 @@ type Server struct {
 	idTokensValidFor       time.Duration
 	authRequestsValidFor   time.Duration
 	deviceRequestsValidFor time.Duration
+
+	signingKeyNoStore bool
 
 	refreshTokenPolicy *RefreshTokenPolicy
 
@@ -273,6 +278,7 @@ func newServer(ctx context.Context, c Config, rotationStrategy rotationStrategy)
 		idTokensValidFor:       value(c.IDTokensValidFor, 24*time.Hour),
 		authRequestsValidFor:   value(c.AuthRequestsValidFor, 24*time.Hour),
 		deviceRequestsValidFor: value(c.DeviceRequestsValidFor, 5*time.Minute),
+		signingKeyNoStore:      c.SigningKeyNoStore,
 		refreshTokenPolicy:     c.RefreshTokenPolicy,
 		skipApproval:           c.SkipApprovalScreen,
 		alwaysShowLogin:        c.AlwaysShowLoginScreen,


### PR DESCRIPTION
If `expiry.signingKeyNoStore` is set to `true`, the Cache-Control response header for key requests is set to `no-store`.